### PR TITLE
Fixing the bas64 encoding strategy

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,11 @@
 module.exports = {
-  base64: require('base64'),
+  base64: {
+    atob: function atob(str){
+      return decodeURIComponent(window.atob(str));
+    },
+    btoa: function btoa(str){
+      return window.btoa(encodeURIComponent(str));
+    }
+  },
   noop: function(){}
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,10 +1,24 @@
+'use strict';
+
+/**
+ * @function
+ * From: https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#Solution_.232_.E2.80.93_rewriting_atob()_and_btoa()_using_TypedArrays_and_UTF-8
+ */
+
+function b64EncodeUnicode(str) {
+  return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
+    return String.fromCharCode('0x' + p1);
+  }));
+}
+
 module.exports = {
   base64: {
     atob: function atob(str){
       return decodeURIComponent(window.atob(str));
     },
     btoa: function btoa(str){
-      return window.btoa(encodeURIComponent(str));
+      var v = b64EncodeUnicode(str);
+      return v;
     }
   },
   noop: function(){}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "grunt-prompt": "^1.1.0"
   },
   "dependencies": {
-    "Base64": "^0.3.0"
+
   }
 }

--- a/test/data/unicode-password.json
+++ b/test/data/unicode-password.json
@@ -1,0 +1,5 @@
+{
+  "login": "hello",
+  "password": "£Passw0rd£",
+  "encoded": "aGVsbG86wqNQYXNzdzByZMKj"
+}

--- a/test/spec/client.js
+++ b/test/spec/client.js
@@ -134,6 +134,24 @@ describe('Client', function () {
       });
     });
 
+    describe('if called with unicode characters', function(){
+      var result;
+      var data = require('../data/unicode-password.json');
+      var input = {
+        login: data.login,
+        password: data.password
+      };
+      before(function(done){
+        client.login(input,function(err){
+          result = [err];
+          done();
+        });
+      });
+      it('should post the correct base64 encoded string to the API',function(){
+        assert.deepEqual(calledWith[2].body,{type:'basic',value:data.encoded});
+      });
+    });
+
     describe('if called with an account store',function(){
       var result;
       var data = require('../data/basic-login.json');
@@ -151,7 +169,7 @@ describe('Client', function () {
         });
       });
       it('should pass the account store to the api',function(){
-        assert.equal(calledWith[2].body.accountStore.href,input.accountStore.href);
+        assert.equal(calledWith[3].body.accountStore.href,input.accountStore.href);
       });
     });
   });


### PR DESCRIPTION
The previous strategy was not working for passwords that had unicode characters